### PR TITLE
Better dk spelling

### DIFF
--- a/locale/cz.json
+++ b/locale/cz.json
@@ -25,7 +25,7 @@
             "fr": "Francouzština",
             "fi": "Finština",
             "ru": "Ruština",
-            "dk": "Dánský",
+            "dk": "Dánština",
             "no": "Norština",
             "ie": "Irština",
             "se": "Švédština",


### PR DESCRIPTION
This way it feels more natural. Google translate isn't that good.

Dansky is more like American (nation),
where Dánština is English (language)