### PR TITLE
Make Google have a seperate UserAgent

### DIFF
--- a/src/main/tools/view.ts
+++ b/src/main/tools/view.ts
@@ -63,5 +63,21 @@ export const navigateView = (id, url) => {
     const { view } = appWindow.getViewFromId(id);
     if(!view) return;
 
+    if (url.includes('google.com' || url.includes('youtube.com')) === true) {
+        view.webContents.userAgent =
+          view.webContents.userAgent
+            .replace(/ DotBrowser\\?.([^\s]+)/g, '')
+            .replace(/ Electron\\?.([^\s]+)/g, '')
+            .replace(/ AppleWebKit\\?.([^\s]+)/g, '')
+            .replace(/ Safari\\?.([^\s]+)/g, '')
+            .replace(/Chrome\\?.([^\s]+)/g, `Gecko/20100101 Firefox/76.0`)
+    } else {
+        view.webContents.userAgent =
+          view.webContents.userAgent
+          .replace(/ dot\\?.([^\s]+)/g, '')
+          .replace(/ Electron\\?.([^\s]+)/g, '')
+          .replace(/Chrome\\?.([^\s]+)/g, `Chrome/81.0.4044.122`)
+    }
+
     view.webContents.loadURL(url)
 }

--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -36,11 +36,9 @@ export class View {
 
         this.view.webContents.userAgent =
           this.view.webContents.userAgent
-          .replace(/ DotBrowser\\?.([^\s]+)/g, '')
+          .replace(/ dot\\?.([^\s]+)/g, '')
           .replace(/ Electron\\?.([^\s]+)/g, '')
-          .replace(/ AppleWebKit\\?.([^\s]+)/g, '')
-          .replace(/ Safari\\?.([^\s]+)/g, '')
-          .replace(/Chrome\\?.([^\s]+)/g, `Gecko/20100101 Firefox/76.0`)
+          .replace(/Chrome\\?.([^\s]+)/g, `Chrome/81.0.4044.122`)
 
         this.view.setAutoResize({ width: true, height: true, horizontal: false, vertical: false });
         this.view.webContents.loadURL(url);


### PR DESCRIPTION
This PR includes code to detect if a website URL has the string 'google.com' (Google URLS) or 'youtube.com' (YouTube URLS), and changes the user agent to Firefox.
You could add code to guess what UA Firefox should use, and could modify the Firefox UA more, this just provides a starting point.

This PR fixes dothq/browser-desktop#221 and reverts commit 774e01a, making the default UA DotBrowser.