### PR TITLE
Enable HTTPS-only mode by default

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2414,6 +2414,9 @@ pref("first-startup.timeout", 30000);
   pref("default-browser-agent.enabled", true);
 #endif
 
+// Enable HTTPS-only mode
+pref("dom.security.https_only_mode", true);
+
 pref("layout.css.backdrop-filter.enabled", true);
 pref("general.autoScroll", true);
 pref("gfx.webrender.all", true);


### PR DESCRIPTION
In March 2020, Firefox [previewed a new optional preference](https://www.ghacks.net/2020/03/24/firefox-76-gets-optional-https-only-mode/) called HTTPS-only mode that would route all traffic from HTTP to HTTPS and if there was no secure version of the site available, would show a confirmation dialog for the user. 

HTTPS-only mode was designed to replicate and replace [HTTPS Everywhere](https://www.eff.org/https-everywhere), a web extension built by the EFF to force secure web browsing. Dot could improve it's security with very little hindrance to the user by enabling the HTTPS-only preference by default.